### PR TITLE
Remove the 'Runtimes' folder during compilation

### DIFF
--- a/src/DCSBIOSDataBroker/DCSBIOSDataBroker.csproj
+++ b/src/DCSBIOSDataBroker/DCSBIOSDataBroker.csproj
@@ -18,6 +18,8 @@
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
     <PackageIcon>app_image_128x128.jpg</PackageIcon>
     <ApplicationIcon>images\app_icon.ico</ApplicationIcon>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="AssemblyInfo.cs" />


### PR DESCRIPTION
* Remove the 'Runtimes' folder
Program will be compiled in the 'win-x64' folder. No more extra 'runtimes' folder

As clean as it gets
![image](https://github.com/DCS-Skunkworks/DCSBIOSDataBroker/assets/67550369/567731f0-09af-4353-9b46-cf99b83744e2)
